### PR TITLE
feat: Add support for OpenWrt 23.05 (reusing the 24.10 IPK package feed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.1.0-r13 — 2026-07-15
+
+### Added
+
+- OpenWrt / ImmortalWrt 23.05 (`opkg`) support: the package is architecture-independent and all runtime dependencies (`rpcd-mod-ucode`, `ucode`, `conntrack`, `netbird`) are available in the 23.05 feeds, so the 24.10 ipk feed installs there unchanged. The feed script and the in-app updater now recognize 23.05 releases. Verified on OpenWrt 23.05.4. Note: the 23.05 packages feed ships an old netbird (0.24.x) — connect / status / settings work, but exit-node selection needs netbird 0.35+; switch the binary to the latest official release on the Versions tab.
+
 ## 0.1.0-r12 — 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **English** | [简体中文](README.zh-cn.md)
 
 LuCI app for the [NetBird](https://netbird.io) mesh-VPN client on OpenWrt / ImmortalWrt — manage NetBird on OpenWrt from the router, no command line needed.
-Compatible with OpenWrt / ImmortalWrt 24.x (`opkg`) and 25.x / current snapshots (`apk`).
+Compatible with OpenWrt / ImmortalWrt 23.05 / 24.x (`opkg`) and 25.x / current snapshots (`apk`).
 
 ## Features
 
@@ -48,7 +48,7 @@ opkg install luci-app-netbird
 Runtime deps (usually present): `rpcd`, `rpcd-mod-ucode`, `luci-base`, `netbird`, `conntrack`.
 
 ```sh
-# OpenWrt / ImmortalWrt 24.10 (opkg)
+# OpenWrt / ImmortalWrt 23.05 / 24.10 (opkg)
 opkg install rpcd rpcd-mod-ucode luci-base netbird
 opkg install luci-app-netbird_*.ipk
 # OpenWrt / ImmortalWrt 25+ (apk)
@@ -81,6 +81,7 @@ Add this repo to an OpenWrt / ImmortalWrt SDK or buildroot (under `package/` or 
 
 - Verified on x86_64; other architectures (arm64 / 386 / armv6) are supported but less tested.
 - SSH extensions (root login / SFTP / port forwarding) require netbird 0.72.x+.
+- The OpenWrt 23.05 package feed ships an old netbird (0.24.x): connect / status / settings work, but exit-node selection needs netbird 0.35+ — switch the binary to the latest official release on the **Versions** tab after installing.
 - `/etc/config/netbird` is a conffile — settings are kept across upgrades.
 
 ## License

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -7,7 +7,7 @@
 [English](README.md) | **简体中文**
 
 OpenWrt / ImmortalWrt 上管理 [NetBird](https://netbird.io) mesh-VPN 客户端的 LuCI 应用 —— 在路由器上使用 NetBird，无需命令行。
-同时兼容 OpenWrt / ImmortalWrt 24.x（`opkg`）和 25.x / 最新 snapshot（`apk`）。
+同时兼容 OpenWrt / ImmortalWrt 23.05 / 24.x（`opkg`）和 25.x / 最新 snapshot（`apk`）。
 
 ## 功能
 
@@ -48,7 +48,7 @@ opkg install luci-app-netbird luci-i18n-netbird-zh-cn
 运行依赖(通常已随固件存在):`rpcd`、`rpcd-mod-ucode`、`luci-base`、`netbird`、`conntrack`。
 
 ```sh
-# OpenWrt / ImmortalWrt 24.10(opkg)
+# OpenWrt / ImmortalWrt 23.05 / 24.10(opkg)
 opkg install rpcd rpcd-mod-ucode luci-base netbird
 opkg install luci-app-netbird_*.ipk luci-i18n-netbird-zh-cn_*.ipk
 # OpenWrt / ImmortalWrt 25+(apk)
@@ -80,6 +80,7 @@ apk add --allow-untrusted luci-app-netbird-*.apk luci-i18n-netbird-zh-cn-*.apk
 
 - 已在 x86_64 验证；其他架构（arm64 / 386 / armv6）支持但测试较少。
 - SSH 扩展（Root 登录 / SFTP / 端口转发）需 netbird 0.72.x+。
+- OpenWrt 23.05 官方源的 netbird 较旧（0.24.x）：连接 / 状态 / 设置可用，但 exit node 选择需 netbird 0.35+ —— 安装后请在「**版本**」页把二进制切换到最新官方 release。
 - `/etc/config/netbird` 是 conffile —— 升级保留你的设置。
 
 ## 许可

--- a/feed/feed.sh
+++ b/feed/feed.sh
@@ -14,6 +14,10 @@ fi
 # branch by release; the package is arch-independent (PKGARCH:=all)
 . /etc/openwrt_release
 case "$DISTRIB_RELEASE" in
+	# 23.05 is opkg-based and the package is arch-independent, so the
+	# 24.10 ipk feed installs there unchanged (all runtime deps —
+	# rpcd-mod-ucode, ucode, conntrack, netbird — exist in 23.05 feeds).
+	*23.05*) BRANCH="openwrt-24.10" ;;
 	*24.10*) BRANCH="openwrt-24.10" ;;
 	*25.12*) BRANCH="openwrt-25.12" ;;
 	*SNAPSHOT*)
@@ -22,11 +26,11 @@ case "$DISTRIB_RELEASE" in
 			# so the 25.12 apk feed installs there unchanged.
 			BRANCH="openwrt-25.12"
 		else
-			echo "opkg-based snapshot builds are not supported; use a 24.10/25.12 release or a current apk-based snapshot." >&2
+			echo "opkg-based snapshot builds are not supported; use a 23.05/24.10/25.12 release or a current apk-based snapshot." >&2
 			exit 1
 		fi
 		;;
-	*) echo "Unsupported release: $DISTRIB_RELEASE (supported: 24.10, 25.12, snapshot)." >&2; exit 1 ;;
+	*) echo "Unsupported release: $DISTRIB_RELEASE (supported: 23.05, 24.10, 25.12, snapshot)." >&2; exit 1 ;;
 esac
 FEED="$REPO/$BRANCH/all/$NAME"
 

--- a/luci-app-netbird/Makefile
+++ b/luci-app-netbird/Makefile
@@ -30,7 +30,7 @@ LUCI_MAINTAINER:=looong-cat <foxhis11@gmail.com>
 
 PKG_NAME:=luci-app-netbird
 PKG_VERSION:=0.1.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 PKG_MAINTAINER:=looong-cat <foxhis11@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/luci-app-netbird/root/usr/share/rpcd/ucode/netbird.uc
+++ b/luci-app-netbird/root/usr/share/rpcd/ucode/netbird.uc
@@ -1589,6 +1589,12 @@ function _openwrt_release_string() {
 
 function _openwrt_series() {
     let rel = _openwrt_release_string();
+    // 23.05(opkg)与 24.10 共用 ipk 软件源:包 PKGARCH:=all 且运行依赖
+    // (rpcd-mod-ucode/ucode/conntrack/netbird)在 23.05 官方源齐备,直接映射同系列。
+    // 注意 23.05 官方源 netbird 较旧(0.24.x,无 networks 子命令):基础连接/状态可用,
+    // exit node 需在「版本」页切换到官方 release 二进制(≥0.35)。
+    if (match(rel, /^23\.05(\.|$)/))
+        return '24.10';
     if (match(rel, /^24\.10(\.|$)/))
         return '24.10';
     if (match(rel, /^25\.12(\.|$)/))

--- a/site/index.html
+++ b/site/index.html
@@ -236,7 +236,7 @@
         manage <strong>NetBird on OpenWrt</strong> from the LuCI dashboard,
         no command line needed.
         <br>
-        Compatible with <strong>OpenWrt / ImmortalWrt 24.x</strong> (<code>opkg</code>)
+        Compatible with <strong>OpenWrt / ImmortalWrt 23.05 / 24.x</strong> (<code>opkg</code>)
         and <strong>25.x / current snapshots</strong> (<code>apk</code>).
       </p>
 
@@ -608,7 +608,7 @@ opkg install luci-app-netbird</pre>
       <h2>Downloads</h2>
       <p class="section-desc">
         Latest <strong>NetBird packages for OpenWrt</strong> —
-        architecture-independent, available as <code>.ipk</code> (24.10) and <code>.apk</code> (25+).
+        architecture-independent, available as <code>.ipk</code> (23.05 / 24.10) and <code>.apk</code> (25+).
       </p>
       <div class="downloads-wrap">
         <p class="signed-badge">🔒 Signed feed — opkg: <code>usign</code> · apk: <code>EC (prime256v1)</code></p>

--- a/site/zh-cn.html
+++ b/site/zh-cn.html
@@ -235,7 +235,7 @@
         <strong>NetBird</strong> mesh-VPN 客户端的 <strong>LuCI Web UI</strong>——
         在路由器后台使用 NetBird，无需命令行。
         <br>
-        同时兼容 <strong>OpenWrt / ImmortalWrt 24.x</strong>（<code>opkg</code>）
+        同时兼容 <strong>OpenWrt / ImmortalWrt 23.05 / 24.x</strong>（<code>opkg</code>）
         和 <strong>25.x / 最新 snapshot</strong>（<code>apk</code>）。
       </p>
 
@@ -582,7 +582,7 @@ opkg install luci-app-netbird luci-i18n-netbird-zh-cn</pre>
       <h2>下载</h2>
       <p class="section-desc">
         最新 <strong>NetBird OpenWrt 软件包</strong>——
-        与架构无关，提供 <code>.ipk</code>（24.10）和 <code>.apk</code>（25+）两种格式。
+        与架构无关，提供 <code>.ipk</code>（23.05 / 24.10）和 <code>.apk</code>（25+）两种格式。
       </p>
       <div class="downloads-wrap">
         <p class="signed-badge">🔒 已签名软件源 — opkg: <code>usign</code> · apk: <code>EC (prime256v1)</code></p>


### PR DESCRIPTION
## Summary

  The app already runs unmodified on OpenWrt 23.05 — the only blockers were the release whitelists in `feed/feed.sh` and in the in-app updater (`_openwrt_series()` in `netbird.uc`). This PR maps `23.05` to the existing `openwrt-24.10` ipk feed (the package is `PKGARCH:=all`, so the same ipk installs unchanged) and updates the docs/site compatibility claims.

  ## Why this is safe (checked against the 23.05.4 package indexes)

  | Requirement | 23.05.4 status |
  | --- | --- |
  | `rpcd-mod-ucode` | ✅ base feed (`2023-07-01-c07ab2f9`) |
  | ucode builtins used by the backend (`uniq`, `match`, `slice`, `loadfile`, …) | ✅ ucode `2024-07-11` in base feed |
  | LuCI client APIs used (`form.Map`, `rpc.declare`, `ui.showModal`, `pont in 23.05 `luci-base` |
  | fw4 zone/forwarding automation | ✅ fw4 is the 23.05 default |
  | `conntrack` | ✅ packages feed (`1.4.8-1`) |
  | `netbird` | ✅ packages feed (`0.24.3` — old, see note) |
  | Installing the 24.10-built ipk | ✅ `Architecture: all`, every `Depen3.05 |

  **Note on the old `netbird` 0.24.3 in the 23.05 feed:** `status --json` and `init.d/netbird-settings` already capability-gates flags via `up--help`, so connect / status / settings work out of the box. Exit-node selection needs the `networks` subcommand (0.35+) — which the Versions tab already solves (switch
  the binary to the official release). Added a Notes bullet about this in

  ## Tested

  Installed on a real OpenWrt 23.05.4 router by adding the `openwrt-24.10ey + `customfeeds.conf` — i.e. exactly what `feed.sh` does after thischange): the app installs, connects, and operates normally.

  ## Changes

  - `feed/feed.sh`: accept `23.05` → `openwrt-24.10` branch; error messages updated
  - `netbird.uc` `_openwrt_series()`: map `23.05` to the `24.10` series sate works (previously returned "Unsupported OpenWrt release: 23.05.4")
  - READMEs + landing pages: compatibility claims + 23.05 note
  - `CHANGELOG.md` entry + `PKG_RELEASE` → 13 per the docs/RELEASING.md cto fold these into your next release instead
